### PR TITLE
Fix issues with PostCSS plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,14 +4,14 @@ var renderPostCSS = function (data, options) {
     var plugins = Object.keys(hexo.config.postcss.plugins)
         .map(function (pluginName) {
             return require(pluginName)
-                (hexo.config.postcss.plugins.pluginName || undefined);
+                (hexo.config.postcss.plugins[pluginName] || undefined);
         });
 
     return postcss(plugins)
-        .process(data.text)
+        .process(data)
         .then(function (result) {
             return result.css;
         });
 };
 
-hexo.extend.renderer.register('css', 'css', renderPostCSS);
+hexo.extend.filter.register('after_render:css', renderPostCSS);


### PR DESCRIPTION
1. `plugins[pluginName]` allows access to plugins with hyphen in their name, such as `postcss-svg`.
2. `data` works with all plugins I’ve tested, `data.text` only works with some (sometime an `TypeError: Cannot read property 'toString' of undefined` error is thrown).
3. Filter `after_render:css` allows for PostCSS usage in conjunction with other parsers like SASS.
